### PR TITLE
Bugfix/update mysql package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,8 +59,8 @@ when 'debian'
         default['mysql']['client']['packages'] = %w(mysql-common-5.6 mysql-client-core-5.6 mysql-client-5.6)
         default['mysql']['server']['packages'] = %w(mysql-common-5.6 mysql-server-5.6)
     when '16.04'
-        default['mysql']['client']['packages'] = %w(mysql-common-5.7 mysql-client-core-5.7 mysql-client-5.7)
-        default['mysql']['server']['packages'] = %w(mysql-common-5.7 mysql-server-5.7)
+        default['mysql']['client']['packages'] = %w(mysql-common mysql-client-core-5.7 mysql-client-5.7)
+        default['mysql']['server']['packages'] = %w(mysql-common mysql-server-5.7)
     end
 when 'fedora', 'rhel', 'centos'
     default['mysql']['service']      = 'mysqld'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.4.4'
+version             '0.4.5'
 source_url          'https://github.com/copious-cookbooks/mysql'
 issues_url          'https://github.com/copious-cookbooks/mysql/issues'
 


### PR DESCRIPTION
Fixes this error message when running on Ubuntu:
```
==> data: Recipe: cop_mysql::install_server
==> data:   * apt_package[mysql-common-5.7] action install
==> data:
==> data:     * No candidate version available for mysql-common-5.7
==> data:
==> data:
==> data: ================================================================================
==> data:
==> data: Error executing action `install` on resource 'apt_package[mysql-common-5.7]'
==> data:
==> data: ================================================================================
```