### PR TITLE
Refactor Package and Repository Installation / Validate Chef v13

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,9 +7,8 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.16.42
-  # NOTE: Rolled back Chef version due to version 12.17.44 incompatibilities
-  #       with Debian Wheezy
+  require_chef_omnibus: 13.1.31
+  # Last tested version
 
 platforms:
   - name: ubuntu/xenial64 # 16.04

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.7.4'
+version             '0.7.5'
 source_url          'https://github.com/copious-cookbooks/mysql'
 issues_url          'https://github.com/copious-cookbooks/mysql/issues'
 

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -16,25 +16,17 @@ end
 
 case node['platform_family']
 when 'debian'
+
     # NOTE: support for https in apt repos
     package 'apt-transport-https' do
         action :install
     end
 
-    execute 'import mysql gpg' do
-        command "apt-key add #{cache}/mysql.asc"
-        # NOTE: mysql public key id: 5072e1f5
-        not_if  'apt-key list | grep 5072e1f5'
-        action  :run
-    end
-
-    file 'install mysql repo' do
-        path    node['mysql']['repo_path']
-        content "deb https://repo.mysql.com/apt/#{node['platform']}/ #{node['lsb']['codename']} mysql-5.7"
-        user   'root'
-        group  'root'
-        mode   0644
-        action :create_if_missing
+    apt_repository 'mysql' do
+        uri "https://repo.mysql.com/apt/#{node['platform']}/"
+        distribution "#{node['lsb']['codename']}"
+        key "https://repo.mysql.com/RPM-GPG-KEY-mysql"
+        components ['mysql-5.7']
         notifies :run, 'execute[update apt]', :immediately
     end
 

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -30,11 +30,6 @@ when 'debian'
         notifies :run, 'execute[update apt]', :immediately
     end
 
-    execute 'update apt' do
-        command 'apt-get update'
-        action  :nothing
-    end
-
 when 'rhel'
 
     yum_repository 'mysql' do

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -3,17 +3,6 @@
 # Recipe:: dependencies
 #
 
-cache = Chef::Config[:file_cache_path]
-
-remote_file 'download mysql gpg key' do
-    path   "#{cache}/mysql.asc"
-    source 'https://repo.mysql.com/RPM-GPG-KEY-mysql'
-    owner  'root'
-    group  'root'
-    mode   0644
-    action :create_if_missing
-end
-
 case node['platform_family']
 when 'debian'
 

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -42,26 +42,18 @@ when 'debian'
         command 'apt-get update'
         action  :nothing
     end
+
 when 'rhel'
-    file 'install mysql repo' do
-        path    node['mysql']['repo_path']
-        content "[mysql57-community]
-name=MySQL 5.7 Community Server
-baseurl=https://repo.mysql.com/yum/mysql-5.7-community/el/#{node['platform_version'].to_i}/$basearch/
-enabled=1
-gpgcheck=1"
-        user   'root'
-        group  'root'
-        mode   0644
-        action :create_if_missing
+
+    yum_repository 'mysql' do
+        description "MySQL 5.7 Community Repository"
+        baseurl "https://repo.mysql.com/yum/mysql-5.7-community/el/#{node['platform_version'].to_i}/$basearch/"
+        enabled true
+        gpgcheck true
+        gpgkey "https://repo.mysql.com/RPM-GPG-KEY-mysql"
+        action :create
     end
 
-    execute 'import mysql gpg' do
-        command "rpm --import #{cache}/mysql.asc"
-        # NOTE: mysql public key id: 5072e1f5
-        not_if  'rpm -qa gpg-pubkey* | grep 5072e1f5'
-        action  :run
-    end
 end
 
 node['mysql']['dependencies'].each do |dep|

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -43,10 +43,8 @@ when 'rhel'
 
 end
 
-node['mysql']['dependencies'].each do |dep|
-    package dep do
-        action :install
-    end
+package node['mysql']['dependencies'] do
+    action :install
 end
 
 gem_package 'mysql2' do

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -16,7 +16,6 @@ when 'debian'
         distribution "#{node['lsb']['codename']}"
         key "https://repo.mysql.com/RPM-GPG-KEY-mysql"
         components ['mysql-5.7']
-        notifies :run, 'execute[update apt]', :immediately
     end
 
 when 'rhel'

--- a/recipes/install_client.rb
+++ b/recipes/install_client.rb
@@ -7,10 +7,8 @@ include_recipe 'cop_mysql::dependencies'
 
 mysql_packages = node['mysql']['client']['packages']
 
-mysql_packages.each do |pkg|
-    package pkg do
-        action :install
-    end
+package mysql_packages do
+	action :install
 end
 
 file node['mysql']['conf_file'] do

--- a/recipes/install_client.rb
+++ b/recipes/install_client.rb
@@ -5,10 +5,8 @@
 
 include_recipe 'cop_mysql::dependencies'
 
-mysql_packages = node['mysql']['client']['packages']
-
-package mysql_packages do
-	action :install
+package node['mysql']['client']['packages'] do
+    action :install
 end
 
 file node['mysql']['conf_file'] do

--- a/recipes/install_server.rb
+++ b/recipes/install_server.rb
@@ -8,10 +8,8 @@ include_recipe 'cop_mysql::dependencies'
 service        = node['mysql']['service']
 mysql_packages = node['mysql']['server']['packages']
 
-mysql_packages.each do |pkg|
-    package pkg do
-        action :install
-    end
+package mysql_packages do
+    action :install
 end
 
 directory node['mysql']['log_dir'] do

--- a/recipes/install_server.rb
+++ b/recipes/install_server.rb
@@ -5,10 +5,9 @@
 
 include_recipe 'cop_mysql::dependencies'
 
-service        = node['mysql']['service']
-mysql_packages = node['mysql']['server']['packages']
+service = node['mysql']['service']
 
-package mysql_packages do
+package node['mysql']['server']['packages'] do
     action :install
 end
 


### PR DESCRIPTION
Uses native Chef `apt` and `yum` repository resources. Simplifies package installation by removing `.each do |x|` loops. Validates Chef v13, even Debian Wheezy which had been a problem child in late stage Chef v12 updates.

Kitchen tests pass as expected with no failures.

Fixes #22 and #24