### PR TITLE
Support for databags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,38 @@ already set a root password in your database, then set this attribute to `false`
 * `node['mysql']['root_password']` defaults to `hMw8oVg3nz2j0TBjy6Z1/Q==`,
 you need to override this attribute with your own root password.
 
+This attribute can optionally be saved in a databag (or encrypted databag), so long as the
+bucket is `mysql` and the item/id is the chef environment. An example will be
+shown below.
+
+```
+$ cat chef/data_bags/mysql/development.json
+{
+  "id": "development",
+  "root_password": "baz",
+  ...
+}
+```
+
 ### User / Database Attributes
 * `node['mysql']['databases']` needs to be a hash
 * `node['mysql']['users']` needs to be a hash of named hashes
+
+The users attribute can optionally be saved in a databag (or encrypted databag), so long as the
+bucket is `mysql` and the item/id is the chef environment. An example will be
+shown below. The passwords will be merged together in the Chef run.
+
+```
+$ cat chef/data_bags/mysql/development.json
+{
+  "id": "development",
+  "users": {
+    "foo": {
+      "password": "bar"
+    }
+  }
+}
+```
 
 Examples are farther below.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,11 @@ default['mysql']['databases']     = { }
 default['mysql']['users']         = { }
 default['mysql']['log_dir']       = '/var/log/mysql/'
 default['mysql']['datadir']       = '/var/lib/mysql'
-default['mysql']['root_password'] = 'hMw8oVg3nz2j0TBjy6Z1/Q=='
+default['mysql']['root_password'] = begin
+                                        data_bag('mysql', node.chef_environment)['root_password']
+                                    rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
+                                        'hMw8oVg3nz2j0TBjy6Z1/Q=='
+                                    end
 
 # https://tools.percona.com/wizard for base config generation
 default['mysql']['conf'] = {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,12 +3,7 @@ default['mysql']['databases']     = { }
 default['mysql']['users']         = { }
 default['mysql']['log_dir']       = '/var/log/mysql/'
 default['mysql']['datadir']       = '/var/lib/mysql'
-default['mysql']['root_password'] = begin
-                                        password = data_bag_item('mysql', node.chef_environment)
-                                        password['root_password']
-                                    rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
-                                        'hMw8oVg3nz2j0TBjy6Z1/Q=='
-                                    end
+default['mysql']['root_password'] = 'hMw8oVg3nz2j0TBjy6Z1/Q=='
 
 # https://tools.percona.com/wizard for base config generation
 default['mysql']['conf'] = {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ default['mysql']['users']         = { }
 default['mysql']['log_dir']       = '/var/log/mysql/'
 default['mysql']['datadir']       = '/var/lib/mysql'
 default['mysql']['root_password'] = begin
-                                        data_bag('mysql', node.chef_environment)['root_password']
+                                        data_bag_item('mysql', node.chef_environment)['root_password']
                                     rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
                                         'hMw8oVg3nz2j0TBjy6Z1/Q=='
                                     end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,8 @@ default['mysql']['users']         = { }
 default['mysql']['log_dir']       = '/var/log/mysql/'
 default['mysql']['datadir']       = '/var/lib/mysql'
 default['mysql']['root_password'] = begin
-                                        data_bag_item('mysql', node.chef_environment)['root_password']
+                                        password = data_bag_item('mysql', node.chef_environment)
+                                        password['root_password']
                                     rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
                                         'hMw8oVg3nz2j0TBjy6Z1/Q=='
                                     end

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -15,7 +15,7 @@ connection_info = {
 # reset and should not be changed again by Chef
 lock = "#{node['mysql']['datadir']}/password_locked"
 
-node.set['mysql']['root_password'] = begin
+node.default['mysql']['root_password'] = begin
                                          data_bag_item('mysql', node.chef_environment)['root_password']
                                      rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
                                          node['mysql']['root_password']

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -15,11 +15,11 @@ connection_info = {
 # reset and should not be changed again by Chef
 lock = "#{node['mysql']['datadir']}/password_locked"
 
-default['mysql']['root_password'] = begin
-                                        data_bag_item('mysql', node.chef_environment)['root_password']
-                                    rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
-                                        node['mysql']['root_password']
-                                    end
+node.set['mysql']['root_password'] = begin
+                                         data_bag_item('mysql', node.chef_environment)['root_password']
+                                     rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
+                                         node['mysql']['root_password']
+                                     end
 case node['platform_family']
 when 'fedora', 'rhel', 'centos'
     ruby_block "get password" do

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -15,11 +15,14 @@ connection_info = {
 # reset and should not be changed again by Chef
 lock = "#{node['mysql']['datadir']}/password_locked"
 
+# NOTE: grab sensitive password from databag if its found, or else default the
+#       generated one in the attributes
 node.default['mysql']['root_password'] = begin
-                                         data_bag_item('mysql', node.chef_environment)['root_password']
-                                     rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
-                                         node['mysql']['root_password']
-                                     end
+                                             data_bag_item('mysql', node.chef_environment)['root_password']
+                                         rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
+                                             node['mysql']['root_password']
+                                         end
+
 case node['platform_family']
 when 'fedora', 'rhel', 'centos'
     ruby_block "get password" do

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -15,6 +15,11 @@ connection_info = {
 # reset and should not be changed again by Chef
 lock = "#{node['mysql']['datadir']}/password_locked"
 
+default['mysql']['root_password'] = begin
+                                        data_bag_item('mysql', node.chef_environment)['root_password']
+                                    rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
+                                        node['mysql']['root_password']
+                                    end
 case node['platform_family']
 when 'fedora', 'rhel', 'centos'
     ruby_block "get password" do

--- a/recipes/tables_and_users.rb
+++ b/recipes/tables_and_users.rb
@@ -23,8 +23,8 @@ sensitive_info = begin
                  end
 
 if sensitive_info
+    node.default['mysql']['users'] = sensitive_info.merge(node['mysql']['users'])
     puts "***: #{node['mysql']['users']}"
-    puts "***2: #{sensitive_info}"
 end
 
 node['mysql']['users'].each do |user, data|

--- a/recipes/tables_and_users.rb
+++ b/recipes/tables_and_users.rb
@@ -22,9 +22,9 @@ sensitive_info = begin
                      nil
                  end
 
+# NOTE: grab sensitive passwords from databag if users are found
 if sensitive_info
     node.default['mysql']['users'] = node['mysql']['users'].merge(sensitive_info)
-    puts "***: #{node['mysql']['users']}"
 end
 
 node['mysql']['users'].each do |user, data|

--- a/recipes/tables_and_users.rb
+++ b/recipes/tables_and_users.rb
@@ -19,10 +19,11 @@ end
 sensitive_info = begin
                      data_bag_item('mysql', node.chef_environment)['users']
                  rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
+                     # NOTE: setting to nil will skip the condition below
                      nil
                  end
 
-# NOTE: grab sensitive passwords from databag if users are found
+# NOTE: merge sensitive passwords with users attribute tree
 if sensitive_info
     node.default['mysql']['users'] = node['mysql']['users'].merge(sensitive_info)
 end

--- a/recipes/tables_and_users.rb
+++ b/recipes/tables_and_users.rb
@@ -17,7 +17,7 @@ node['mysql']['databases'].each do |database|
 end
 
 sensitive_info = begin
-                     data_bag_item('mysql', node.chef_environment)
+                     data_bag_item('mysql', node.chef_environment)['users']
                  rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
                      nil
                  end

--- a/recipes/tables_and_users.rb
+++ b/recipes/tables_and_users.rb
@@ -23,7 +23,7 @@ sensitive_info = begin
                  end
 
 if sensitive_info
-    node.default['mysql']['users'] = sensitive_info.merge(node['mysql']['users'])
+    node.default['mysql']['users'] = node['mysql']['users'].merge(sensitive_info)
     puts "***: #{node['mysql']['users']}"
 end
 

--- a/recipes/tables_and_users.rb
+++ b/recipes/tables_and_users.rb
@@ -16,6 +16,17 @@ node['mysql']['databases'].each do |database|
     end
 end
 
+sensitive_info = begin
+                     data_bag('mysql', node.chef_environment)['users']
+                 rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
+                     nil
+                 end
+
+if sensitive_info
+    puts "***: #{node['mysql']['users']}"
+    puts "***2: #{sensitive_info}"
+end
+
 node['mysql']['users'].each do |user, data|
     mysql_database_user user do
         connection connection_info

--- a/recipes/tables_and_users.rb
+++ b/recipes/tables_and_users.rb
@@ -17,7 +17,7 @@ node['mysql']['databases'].each do |database|
 end
 
 sensitive_info = begin
-                     data_bag('mysql', node.chef_environment)['users']
+                     data_bag_item('mysql', node.chef_environment)['users']
                  rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
                      nil
                  end

--- a/recipes/tables_and_users.rb
+++ b/recipes/tables_and_users.rb
@@ -17,7 +17,7 @@ node['mysql']['databases'].each do |database|
 end
 
 sensitive_info = begin
-                     data_bag_item('mysql', node.chef_environment)['users']
+                     data_bag_item('mysql', node.chef_environment)
                  rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
                      nil
                  end


### PR DESCRIPTION
Provides optional support for sensitive values and passwords. Should not break previous versions of this cookbook.

This PR does not include testing of the databags, it's been validated elsewhere and can be incorporated later.